### PR TITLE
Bugfix for revision hashes in deploy-info.json

### DIFF
--- a/examples/clock/MaidenClockCommon.php
+++ b/examples/clock/MaidenClockCommon.php
@@ -121,7 +121,7 @@ class MaidenClockCommon extends \Maiden\MaidenDefault {
 		$this->exec("git clone -b {$deploymentBranch} . {$tempBuildPath}");
 		chdir($tempBuildPath);
 		$this->exec("git checkout {$version}");
-		$revision = $this->exec("git log --pretty=format:%h -b {$deploymentBranch} | head -n1 ", true, true);
+		$revision = $this->exec("git log --pretty=format:%h -b {$version} | head -n1 ", true, true);
 		$this->exec("git submodule init");
 		$this->exec("git submodule update");
 		chdir($currentDirectory);


### PR DESCRIPTION
The revision number that is stored in deploy-info.json is using the hash of the HEAD commit in the deployment branch. 

In any situation where the tag/version being deployed differs from the deploy branch's HEAD, e.g. deploying a tagged revision from another branch, the wrong revision hash will be saved.
