### PR TITLE
Adding --hide-duration option

### DIFF
--- a/lib/Maiden/MaidenRunner.php
+++ b/lib/Maiden/MaidenRunner.php
@@ -17,6 +17,13 @@ class MaidenRunner {
 	protected $defaultMaidenFile = "Maiden.php";
 
 	/**
+	 * If the duration of the target should be output after execution.
+	 *
+	 * @var boolean
+	 */
+	protected $displayDuration = true;
+
+	/**
 	 * All output should be set to the logger.
 	 *
 	 * @var \Piton\Log\DefaultLogger
@@ -157,11 +164,15 @@ class MaidenRunner {
 			exit(1);
 		}
 
-		$endTime = microtime(true) - $startTime;
+		if ($this->displayDuration) {
+			$endTime = microtime(true) - $startTime;
 
-		$totalTime = number_format($endTime, 2);
+			$totalTime = number_format($endTime, 2);
 
-		$this->logger->log("Maiden has finished in: {$totalTime}");
+			$this->logger->log("Maiden has finished running target {$target} in: {$totalTime}");
+		} else {
+			$this->logger->log("Maiden has finished running target {$target}");
+		}
 	}
 
 	/**
@@ -176,6 +187,10 @@ class MaidenRunner {
 		$definedClasses = get_declared_classes();
 		include $this->defaultMaidenFile;
 		return array_diff(get_declared_classes(), $definedClasses);
+	}
+
+	public function setDisplayDuration($displayDuration) {
+		$this->displayDuration = $displayDuration;
 	}
 
 	public function exceptionErrorHandler($number, $message, $filename, $lineNumber ) {

--- a/maiden
+++ b/maiden
@@ -47,6 +47,12 @@ $options = array(
 			$logger->setLevel($logger::LEVEL_DEBUG);
 		},
 	),
+	"--hide-duration" => array(
+		"description" => "Run target and supress duration",
+		"action" => function($args) use ($maidenRunner) {
+			$maidenRunner->setDisplayDuration(false);
+		},
+	),
 	"-h" => array(
 		"description" => "Displays this usages",
 		"action" => function($args, $options) {


### PR DESCRIPTION
For use when running multiple remote maiden commands, this option can be added to supress duration on individual calls.

Also included the target name in the output for reference: "Maiden finished {$target}"/"Maiden finished {$target} in {$duration}"

Might be overkill, but I find it annoying having multiple "Maiden finished in {$duration}" on completion of the main target.
